### PR TITLE
fix: 修复 Controller.Close() 中遗漏关闭 userListMonitorPeriodic 导致的任务泄漏

### DIFF
--- a/node/controller.go
+++ b/node/controller.go
@@ -83,6 +83,9 @@ func (c *Controller) Start() error {
 // Close implement the Close() function of the service interface
 func (c *Controller) Close() error {
 	limiter.DeleteLimiter(c.tag)
+	if c.userListMonitorPeriodic != nil {
+		c.userListMonitorPeriodic.Close()
+	}
 	if c.userReportPeriodic != nil {
 		c.userReportPeriodic.Close()
 	}


### PR DESCRIPTION
问题:
- 配置重载时 userListMonitorPeriodic 任务未被关闭
- 导致每次重载都会创建新任务但旧任务继续运行
- 多次重载后会有多个任务同时运行,造成 API 请求频率异常增高

影响:
- 部分节点 API 请求频率达到 8-10 次/秒(正常应为 0.1-0.2 次/秒)
- 资源泄漏,浪费 CPU、内存和网络资源

修复:
- 在 Close() 方法中添加对 userListMonitorPeriodic 的关闭调用
- 确保所有定时任务在节点关闭时都能被正确清理