### PR TITLE
fix: 修复 XrayCore.Close() 中遗漏关闭 serverConfigMonitorPeriodic 导致的任务泄漏

### DIFF
--- a/core/xray.go
+++ b/core/xray.go
@@ -73,6 +73,9 @@ func (v *XrayCore) Start(serverconfig *panel.ServerConfigResponse) error {
 func (v *XrayCore) Close() error {
 	v.access.Lock()
 	defer v.access.Unlock()
+	if v.serverConfigMonitorPeriodic != nil {
+		v.serverConfigMonitorPeriodic.Close()
+	}
 	v.Config = nil
 	v.ihm = nil
 	v.ohm = nil


### PR DESCRIPTION
问题描述:
- 在 core/xray.go 的 Close() 方法中,遗漏了对 serverConfigMonitorPeriodic 任务的关闭调用
- 导致每次配置重载时,旧的配置监控任务继续运行
- 多次重载后,多个监控任务同时运行,导致 API 请求频率成倍增加

现象:
- 每次重载后,获取服务端配置的请求频率增加
- 日志显示频繁的'检测到服务端配置变更,正在重启节点...'消息

修复:
- 在 Close() 方法开始处添加关闭 serverConfigMonitorPeriodic 的逻辑
- 确保所有定时任务在 XrayCore 关闭时都能被正确清理

影响范围:
- 修改 1 个文件: core/xray.go
- 新增 3 行代码
- 无破坏性变更