### PR TITLE
[codex] ignore local agent instruction files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,12 @@ app/legocmd/.lego/
 output/*
 .idea/*
 new.sh
+
+# Local agent instructions
+AGENT.md
+AGENTS.md
+agent.md
+agents.md
+CLAUDE.md
+claude.md
+BRANCH_STRATEGY.md


### PR DESCRIPTION
## Summary
- ignore local agent instruction files so they remain local-only and stop showing up in git status
- remove those files from version control where they were previously tracked

## Why
These files are local workspace instructions and memory/context files for AI tooling. They should stay available locally, but they should not be committed to the repository or keep interfering with normal development diffs.

## Validation
- git status inspection
- no runtime tests required for this repository-only housekeeping change
