### PR TITLE
feat: support expanded custom outbound config

### DIFF
--- a/api/panel/server.go
+++ b/api/panel/server.go
@@ -33,12 +33,35 @@ type DNSItem struct {
 }
 
 type Outbound struct {
-	Name     string   `json:"name"`
-	Protocol string   `json:"protocol"`
-	Address  string   `json:"address"`
-	Port     int      `json:"port"`
-	Password string   `json:"password"`
-	Rules    []string `json:"rules"`
+	Name                 string   `json:"name"`
+	Protocol             string   `json:"protocol"`
+	Address              string   `json:"address"`
+	Port                 int      `json:"port"`
+	User                 string   `json:"user"`
+	Password             string   `json:"password"`
+	UUID                 string   `json:"uuid"`
+	Cipher               string   `json:"cipher"`
+	Security             string   `json:"security"`
+	SNI                  string   `json:"sni"`
+	AllowInsecure        bool     `json:"allow_insecure"`
+	Fingerprint          string   `json:"fingerprint"`
+	Transport            string   `json:"transport"`
+	Host                 string   `json:"host"`
+	Path                 string   `json:"path"`
+	ServiceName          string   `json:"service_name"`
+	Flow                 string   `json:"flow"`
+	UoT                  bool     `json:"uot"`
+	UoTVersion           int      `json:"uot_version"`
+	CongestionController string   `json:"congestion_controller"`
+	UDPStream            bool     `json:"udp_stream"`
+	ReduceRTT            bool     `json:"reduce_rtt"`
+	Heartbeat            int      `json:"heartbeat"`
+	RealityPublicKey     string   `json:"reality_public_key"`
+	RealityShortID       string   `json:"reality_short_id"`
+	SpiderX              string   `json:"spider_x"`
+	Settings             string   `json:"settings"`
+	StreamSettings       string   `json:"stream_settings"`
+	Rules                []string `json:"rules"`
 }
 
 type Protocol struct {
@@ -104,7 +127,7 @@ func GetServerConfig(ctx context.Context, c *ClientV2) (*ServerConfigResponse, e
 	if err != nil {
 		return nil, fmt.Errorf("访问 %s 失败: %v", client.BaseURL+path, err.Error())
 	}
-	
+
 	// 检查 HTTP 状态码
 	if r.StatusCode() == 304 {
 		return nil, nil
@@ -113,7 +136,7 @@ func GetServerConfig(ctx context.Context, c *ClientV2) (*ServerConfigResponse, e
 		body := r.Body()
 		return nil, fmt.Errorf("访问 %s 失败: %s", client.BaseURL+path, string(body))
 	}
-	
+
 	// 只有在成功响应时才检查 hash
 	hash := sha256.Sum256(r.Body())
 	newBodyHash := hex.EncodeToString(hash[:])

--- a/common/serverstatus/serverstatus.go
+++ b/common/serverstatus/serverstatus.go
@@ -46,7 +46,7 @@ func GetSystemInfo() (Cpu float64, Mem float64, Disk float64, Uptime uint64, err
 	}
 
 	if errorString != "" {
-		err = fmt.Errorf(errorString)
+		err = fmt.Errorf("%s", errorString)
 	}
 
 	return Cpu, Mem, Disk, Uptime, err

--- a/core/custom.go
+++ b/core/custom.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"strings"
 
@@ -80,6 +81,214 @@ func buildRouteDomains(rules []string) []string {
 		domains = append(domains, value)
 	}
 	return domains
+}
+
+func normalizeOutboundProtocol(protocol string) string {
+	switch strings.ToLower(strings.TrimSpace(protocol)) {
+	case "direct":
+		return "freedom"
+	case "reject", "block":
+		return "blackhole"
+	default:
+		return strings.ToLower(strings.TrimSpace(protocol))
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func rawJSONMessage(value string, field string) (*json.RawMessage, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+	if !json.Valid([]byte(value)) {
+		return nil, fmt.Errorf("invalid outbound %s json", field)
+	}
+	raw := json.RawMessage(value)
+	return &raw, nil
+}
+
+func buildOutboundSettings(item panel.Outbound) (string, *json.RawMessage, error) {
+	protocol := normalizeOutboundProtocol(item.Protocol)
+	if raw, err := rawJSONMessage(item.Settings, "settings"); err != nil || raw != nil {
+		return protocol, raw, err
+	}
+
+	settings := map[string]interface{}{}
+	switch protocol {
+	case "freedom", "blackhole":
+	case "http", "socks":
+		settings["address"] = strings.TrimSpace(item.Address)
+		settings["port"] = item.Port
+		if strings.TrimSpace(item.User) != "" {
+			settings["user"] = strings.TrimSpace(item.User)
+			settings["pass"] = item.Password
+		}
+	case "shadowsocks":
+		settings["address"] = strings.TrimSpace(item.Address)
+		settings["port"] = item.Port
+		settings["method"] = firstNonEmpty(item.Cipher, "chacha20-ietf-poly1305")
+		settings["password"] = item.Password
+		settings["uot"] = true
+		if item.UoT {
+			settings["uot"] = item.UoT
+		}
+		uotVersion := item.UoTVersion
+		if uotVersion == 0 {
+			uotVersion = 2
+		}
+		settings["uotVersion"] = uotVersion
+	case "trojan":
+		settings["address"] = strings.TrimSpace(item.Address)
+		settings["port"] = item.Port
+		settings["password"] = item.Password
+	case "vmess":
+		settings["address"] = strings.TrimSpace(item.Address)
+		settings["port"] = item.Port
+		settings["id"] = firstNonEmpty(item.UUID, item.Password)
+		settings["security"] = firstNonEmpty(item.Cipher, "auto")
+	case "vless":
+		settings["address"] = strings.TrimSpace(item.Address)
+		settings["port"] = item.Port
+		settings["id"] = firstNonEmpty(item.UUID, item.Password)
+		settings["encryption"] = "none"
+		if flow := strings.TrimSpace(item.Flow); flow != "" && flow != "none" {
+			settings["flow"] = flow
+		}
+	case "anytls":
+		settings["address"] = strings.TrimSpace(item.Address)
+		settings["port"] = item.Port
+		settings["password"] = item.Password
+	case "tuic":
+		settings["address"] = strings.TrimSpace(item.Address)
+		settings["port"] = item.Port
+		settings["uuid"] = firstNonEmpty(item.UUID, item.Password)
+		settings["password"] = item.Password
+		if congestion := strings.TrimSpace(item.CongestionController); congestion != "" {
+			settings["congestionControl"] = congestion
+		}
+		settings["udpStream"] = item.UDPStream
+		settings["zeroRttHandshake"] = item.ReduceRTT
+		if item.Heartbeat > 0 {
+			settings["heartbeat"] = item.Heartbeat
+		}
+	case "hysteria":
+		settings["version"] = 2
+		settings["address"] = strings.TrimSpace(item.Address)
+		settings["port"] = item.Port
+	case "wireguard":
+		return "", nil, nil
+	default:
+		return "", nil, nil
+	}
+
+	data, err := json.Marshal(settings)
+	if err != nil {
+		return "", nil, err
+	}
+	raw := json.RawMessage(data)
+	return protocol, &raw, nil
+}
+
+func buildOutboundStreamConfig(item panel.Outbound) (*coreConf.StreamConfig, error) {
+	if raw := strings.TrimSpace(item.StreamSettings); raw != "" {
+		var stream coreConf.StreamConfig
+		if err := json.Unmarshal([]byte(raw), &stream); err != nil {
+			return nil, fmt.Errorf("invalid outbound stream_settings json: %w", err)
+		}
+		return &stream, nil
+	}
+
+	protocol := normalizeOutboundProtocol(item.Protocol)
+	transport := strings.ToLower(strings.TrimSpace(item.Transport))
+	if transport == "" {
+		switch protocol {
+		case "vmess", "vless", "trojan", "anytls":
+			transport = "tcp"
+		case "tuic":
+			transport = "tuic"
+		case "hysteria":
+			transport = "hysteria"
+		}
+	}
+	security := strings.ToLower(strings.TrimSpace(item.Security))
+	hasStreamField := transport != "" ||
+		security != "" ||
+		strings.TrimSpace(item.SNI) != "" ||
+		strings.TrimSpace(item.Fingerprint) != "" ||
+		strings.TrimSpace(item.Host) != "" ||
+		strings.TrimSpace(item.Path) != "" ||
+		strings.TrimSpace(item.ServiceName) != "" ||
+		strings.TrimSpace(item.RealityPublicKey) != "" ||
+		strings.TrimSpace(item.RealityShortID) != ""
+	if !hasStreamField {
+		return nil, nil
+	}
+
+	stream := &coreConf.StreamConfig{Security: security}
+	if transport != "" {
+		t := coreConf.TransportProtocol(transport)
+		stream.Network = &t
+	}
+	switch security {
+	case "", "none":
+	case "tls":
+		stream.TLSSettings = &coreConf.TLSConfig{
+			ServerName:    strings.TrimSpace(item.SNI),
+			AllowInsecure: item.AllowInsecure,
+			Fingerprint:   firstNonEmpty(item.Fingerprint, "chrome"),
+		}
+	case "reality":
+		stream.REALITYSettings = &coreConf.REALITYConfig{
+			ServerName:  strings.TrimSpace(item.SNI),
+			PublicKey:   strings.TrimSpace(item.RealityPublicKey),
+			ShortId:     strings.TrimSpace(item.RealityShortID),
+			Fingerprint: firstNonEmpty(item.Fingerprint, "chrome"),
+			SpiderX:     firstNonEmpty(item.SpiderX, "/"),
+		}
+	default:
+		return nil, fmt.Errorf("unsupported outbound security %q", item.Security)
+	}
+
+	switch transport {
+	case "", "tcp", "raw":
+		if transport != "" {
+			stream.TCPSettings = &coreConf.TCPConfig{}
+		}
+	case "ws", "websocket":
+		stream.WSSettings = &coreConf.WebSocketConfig{
+			Host: strings.TrimSpace(item.Host),
+			Path: strings.TrimSpace(item.Path),
+		}
+	case "grpc":
+		stream.GRPCSettings = &coreConf.GRPCConfig{
+			Authority:   strings.TrimSpace(item.Host),
+			ServiceName: strings.TrimSpace(item.ServiceName),
+		}
+	case "httpupgrade":
+		stream.HTTPUPGRADESettings = &coreConf.HttpUpgradeConfig{
+			Host: strings.TrimSpace(item.Host),
+			Path: strings.TrimSpace(item.Path),
+		}
+	case "splithttp", "xhttp":
+		stream.SplitHTTPSettings = &coreConf.SplitHTTPConfig{
+			Host: strings.TrimSpace(item.Host),
+			Path: strings.TrimSpace(item.Path),
+		}
+	case "tuic", "hysteria":
+	default:
+		return nil, fmt.Errorf("unsupported outbound transport %q", item.Transport)
+	}
+
+	return stream, nil
 }
 
 func GetCustomConfig(serverconfig *panel.ServerConfigResponse) (*dns.Config, []*core.OutboundHandlerConfig, *router.Config, error) {
@@ -202,63 +411,21 @@ func GetCustomConfig(serverconfig *panel.ServerConfigResponse) (*dns.Config, []*
 	//custom outbound
 	if outboundList != nil {
 		for _, outbounditem := range *outboundList {
-			jsonsettings := map[string]interface{}{
-				"address": outbounditem.Address,
-				"port":    outbounditem.Port,
+			protocol, rawSettings, err := buildOutboundSettings(outbounditem)
+			if err != nil {
+				return nil, nil, nil, err
 			}
-			streamSettings := &coreConf.StreamConfig{}
-			switch outbounditem.Protocol {
-			case "http":
-				//jsonsettings["user"] = outbounditem.User
-				jsonsettings["pass"] = outbounditem.Password
-			case "socks":
-				//jsonsettings["user"] = outbounditem.User
-				jsonsettings["pass"] = outbounditem.Password
-			case "shadowsocks":
-				//jsonsettings["method"] = outbounditem.Method
-				jsonsettings["password"] = outbounditem.Password
-				jsonsettings["uot"] = true
-				jsonsettings["UoTVersion"] = 2
-			case "trojan":
-				jsonsettings["password"] = outbounditem.Password
-				proto := coreConf.TransportProtocol("tcp")
-				streamSettings.Network = &proto
-				streamSettings.Security = "tls"
-				streamSettings.TLSSettings = &coreConf.TLSConfig{
-					//ServerName: outbounditem.SNI,
-					//Insecure: outbounditem.Insecure,
-				}
-			case "vmess":
-				jsonsettings["uuid"] = outbounditem.Password
-				proto := coreConf.TransportProtocol("tcp")
-				streamSettings.Network = &proto
-				/*if outbounditem.Security != "" && outbounditem.Security == "tls" {
-					streamSettings.Security = "tls"
-					streamSettings.TLSSettings = &coreConf.TLSConfig{
-						ServerName: outbounditem.SNI,
-						Insecure: outbounditem.Insecure,
-				}*/
-			case "vless":
-				jsonsettings["uuid"] = outbounditem.Password
-				proto := coreConf.TransportProtocol("tcp")
-				streamSettings.Network = &proto
-				/*if outbounditem.Security != "" && outbounditem.Security == "tls" {
-					streamSettings.Security = "tls"
-					streamSettings.TLSSettings = &coreConf.TLSConfig{
-						ServerName: outbounditem.SNI,
-						Insecure: outbounditem.Insecure,
-				}*/
-			//case "wireguard":
-			default:
+			if protocol == "" || rawSettings == nil {
 				continue
 			}
-
-			settings, _ := json.Marshal(jsonsettings)
-			rawSettings := json.RawMessage(settings)
+			streamSettings, err := buildOutboundStreamConfig(outbounditem)
+			if err != nil {
+				return nil, nil, nil, err
+			}
 			outbound := &coreConf.OutboundDetourConfig{
 				Tag:           outbounditem.Name,
-				Protocol:      outbounditem.Protocol,
-				Settings:      &rawSettings,
+				Protocol:      protocol,
+				Settings:      rawSettings,
 				StreamSetting: streamSettings,
 			}
 			// Outbound rules

--- a/core/custom.go
+++ b/core/custom.go
@@ -42,6 +42,46 @@ func hasOutboundWithTag(list []*core.OutboundHandlerConfig, tag string) bool {
 	return false
 }
 
+func buildRouteDomains(rules []string) []string {
+	domains := make([]string, 0, len(rules))
+	seen := make(map[string]struct{}, len(rules))
+	for _, rule := range rules {
+		rule = strings.TrimSpace(rule)
+		if rule == "" {
+			continue
+		}
+
+		value := ""
+		data := strings.SplitN(rule, ":", 2)
+		if len(data) == 2 {
+			data[0] = strings.TrimSpace(data[0])
+			data[1] = strings.TrimSpace(data[1])
+			if data[1] == "" {
+				continue
+			}
+			switch data[0] {
+			case "keyword":
+				value = data[1]
+			case "suffix":
+				value = "domain:" + data[1]
+			case "regex":
+				value = "regexp:" + data[1]
+			default:
+				value = data[1]
+			}
+		} else {
+			value = "full:" + rule
+		}
+
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		domains = append(domains, value)
+	}
+	return domains
+}
+
 func GetCustomConfig(serverconfig *panel.ServerConfigResponse) (*dns.Config, []*core.OutboundHandlerConfig, *router.Config, error) {
 	var ip_strategy string
 	if serverconfig.Data.IPStrategy != "" {
@@ -146,31 +186,16 @@ func GetCustomConfig(serverconfig *panel.ServerConfigResponse) (*dns.Config, []*
 
 	//custom block
 	if blockList != nil {
-		var domains []string
-		for _, bitem := range *blockList {
-			data := strings.Split(bitem, ":")
-			if len(data) == 2 {
-				switch data[0] {
-				case "keyword":
-					domains = append(domains, data[1])
-				case "suffix":
-					domains = append(domains, "domain:"+data[1])
-				case "regex":
-					domains = append(domains, "regexp:"+data[1])
-				default:
-					domains = append(domains, data[1])
-				}
-			} else {
-				domains = append(domains, "full:"+bitem)
+		domains := buildRouteDomains(*blockList)
+		if len(domains) > 0 {
+			rule := map[string]interface{}{
+				"domain":      domains,
+				"outboundTag": "block",
 			}
-		}
-		rule := map[string]interface{}{
-			"domain":      domains,
-			"outboundTag": "block",
-		}
-		rawRule, err := json.Marshal(rule)
-		if err == nil {
-			coreRouterConfig.RuleList = append(coreRouterConfig.RuleList, rawRule)
+			rawRule, err := json.Marshal(rule)
+			if err == nil {
+				coreRouterConfig.RuleList = append(coreRouterConfig.RuleList, rawRule)
+			}
 		}
 	}
 
@@ -237,35 +262,20 @@ func GetCustomConfig(serverconfig *panel.ServerConfigResponse) (*dns.Config, []*
 				StreamSetting: streamSettings,
 			}
 			// Outbound rules
-			var domains []string
-			for _, item := range outbounditem.Rules {
-				data := strings.Split(item, ":")
-				if len(data) == 2 {
-					switch data[0] {
-					case "keyword":
-						domains = append(domains, data[1])
-					case "suffix":
-						domains = append(domains, "domain:"+data[1])
-					case "regex":
-						domains = append(domains, "regexp:"+data[1])
-					default:
-						domains = append(domains, data[1])
-					}
-				} else {
-					domains = append(domains, "full:"+item)
-				}
-			}
+			domains := buildRouteDomains(outbounditem.Rules)
 			custom_outbound, err := outbound.Build()
 			if err != nil {
 				continue
 			}
-			rule := map[string]interface{}{
-				"domain":      domains,
-				"outboundTag": custom_outbound.Tag,
-			}
-			rawRule, err := json.Marshal(rule)
-			if err == nil {
-				coreRouterConfig.RuleList = append(coreRouterConfig.RuleList, rawRule)
+			if len(domains) > 0 {
+				rule := map[string]interface{}{
+					"domain":      domains,
+					"outboundTag": custom_outbound.Tag,
+				}
+				rawRule, err := json.Marshal(rule)
+				if err == nil {
+					coreRouterConfig.RuleList = append(coreRouterConfig.RuleList, rawRule)
+				}
 			}
 			if hasOutboundWithTag(coreOutboundConfig, custom_outbound.Tag) {
 				continue

--- a/core/custom_test.go
+++ b/core/custom_test.go
@@ -50,3 +50,116 @@ func TestBuildRouteDomainsSanitizesRules(t *testing.T) {
 		}
 	}
 }
+
+func TestGetCustomConfigBuildsTypedOutbound(t *testing.T) {
+	dns := []panel.DNSItem{}
+	block := []string{}
+	outbound := []panel.Outbound{
+		{
+			Name:      "proxy",
+			Protocol:  "vless",
+			Address:   "example.com",
+			Port:      443,
+			UUID:      "00000000-0000-0000-0000-000000000001",
+			Security:  "tls",
+			SNI:       "example.com",
+			Transport: "websocket",
+			Host:      "example.com",
+			Path:      "/ws",
+			Rules:     []string{"suffix:example.com"},
+		},
+	}
+	protocols := []panel.Protocol{}
+
+	_, outbounds, routeConfig, err := GetCustomConfig(&panel.ServerConfigResponse{
+		Data: &panel.Data{
+			IPStrategy: "prefer_ipv4",
+			DNS:        &dns,
+			Block:      &block,
+			Outbound:   &outbound,
+			Protocols:  &protocols,
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetCustomConfig() error = %v", err)
+	}
+
+	if got := len(outbounds); got != 4 {
+		t.Fatalf("outbounds len = %d, want 4", got)
+	}
+	if got := len(routeConfig.GetRule()); got != 2 {
+		t.Fatalf("route rules len = %d, want default DNS + custom outbound", got)
+	}
+}
+
+func TestGetCustomConfigUsesRawOutboundSettings(t *testing.T) {
+	dns := []panel.DNSItem{}
+	block := []string{}
+	outbound := []panel.Outbound{
+		{
+			Name:     "direct-cn",
+			Protocol: "direct",
+			Settings: `{"domainStrategy":"UseIPv4"}`,
+			Rules:    []string{"suffix:cn"},
+		},
+	}
+	protocols := []panel.Protocol{}
+
+	_, outbounds, routeConfig, err := GetCustomConfig(&panel.ServerConfigResponse{
+		Data: &panel.Data{
+			IPStrategy: "prefer_ipv4",
+			DNS:        &dns,
+			Block:      &block,
+			Outbound:   &outbound,
+			Protocols:  &protocols,
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetCustomConfig() error = %v", err)
+	}
+
+	if got := len(outbounds); got != 4 {
+		t.Fatalf("outbounds len = %d, want 4", got)
+	}
+	if got := outbounds[3].Tag; got != "direct-cn" {
+		t.Fatalf("custom outbound tag = %q, want direct-cn", got)
+	}
+	if got := len(routeConfig.GetRule()); got != 2 {
+		t.Fatalf("route rules len = %d, want default DNS + custom outbound", got)
+	}
+}
+
+func TestGetCustomConfigSkipsUnsupportedOutboundWithoutRawSettings(t *testing.T) {
+	dns := []panel.DNSItem{}
+	block := []string{}
+	outbound := []panel.Outbound{
+		{
+			Name:     "legacy-naive",
+			Protocol: "naive",
+			Address:  "example.com",
+			Port:     443,
+			Rules:    []string{"suffix:example.com"},
+		},
+	}
+	protocols := []panel.Protocol{}
+
+	_, outbounds, routeConfig, err := GetCustomConfig(&panel.ServerConfigResponse{
+		Data: &panel.Data{
+			IPStrategy: "prefer_ipv4",
+			DNS:        &dns,
+			Block:      &block,
+			Outbound:   &outbound,
+			Protocols:  &protocols,
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetCustomConfig() error = %v", err)
+	}
+
+	if got := len(outbounds); got != 3 {
+		t.Fatalf("outbounds len = %d, want only default outbounds", got)
+	}
+	if got := len(routeConfig.GetRule()); got != 1 {
+		t.Fatalf("route rules len = %d, want only default DNS rule", got)
+	}
+}

--- a/core/custom_test.go
+++ b/core/custom_test.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/perfect-panel/ppanel-node/api/panel"
+)
+
+func TestGetCustomConfigSkipsEmptyBlockRules(t *testing.T) {
+	dns := []panel.DNSItem{}
+	block := []string{}
+	outbound := []panel.Outbound{}
+	protocols := []panel.Protocol{}
+
+	_, _, routeConfig, err := GetCustomConfig(&panel.ServerConfigResponse{
+		Data: &panel.Data{
+			IPStrategy: "prefer_ipv4",
+			DNS:        &dns,
+			Block:      &block,
+			Outbound:   &outbound,
+			Protocols:  &protocols,
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetCustomConfig() error = %v", err)
+	}
+
+	if got := len(routeConfig.GetRule()); got != 1 {
+		t.Fatalf("route rules len = %d, want only default DNS rule", got)
+	}
+}
+
+func TestBuildRouteDomainsSanitizesRules(t *testing.T) {
+	got := buildRouteDomains([]string{
+		" suffix:example.com ",
+		"",
+		"suffix:example.com",
+		"keyword:",
+		" keyword:google ",
+		"plain.example",
+	})
+	want := []string{"domain:example.com", "google", "full:plain.example"}
+
+	if len(got) != len(want) {
+		t.Fatalf("buildRouteDomains() = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("buildRouteDomains()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Skip empty custom routing rules to avoid `app/router: this rule has no effective fields`.
- Expand panel server config structs for custom outbound fields.
- Build structured Xray outbounds for HTTP, SOCKS, Shadowsocks, VMess, VLESS, Trojan, AnyTLS, TUIC, Hysteria2, direct, and reject.
- Support TLS, Reality, and common transport options from backend-delivered config.
- Keep raw `settings` / `stream_settings` support as advanced fallback.
- Fix server status vet issue.