### PR TITLE
policy: restore ConnectionIdle to 120s (matches upstream v2node; fixes idle SSH/long-lived connections dropping at ~60s)

### DIFF
--- a/core/xray.go
+++ b/core/xray.go
@@ -122,7 +122,12 @@ func getCore(c *conf.Conf, serverconfig *panel.ServerConfigResponse) *core.Insta
 		StatsUserUplink:   true,
 		StatsUserDownlink: true,
 		Handshake:         proto.Uint32(4),
-		ConnectionIdle:    proto.Uint32(30),
+		// ppnode lowered this to 30s, which xray's polling activity timer turns
+		// into a ~60s effective timeout, dropping idle-but-healthy long-lived
+		// connections (interactive SSH, database sessions, MQTT/WebSocket, etc.).
+		// Restore it to 120 — the value used by upstream wyx2685/v2node, which
+		// this project is modified from.
+		ConnectionIdle:    proto.Uint32(120),
 		UplinkOnly:        proto.Uint32(2),
 		DownlinkOnly:      proto.Uint32(4),
 		BufferSize:        proto.Int32(64),


### PR DESCRIPTION
### Problem

`core/xray.go` sets the level-0 policy `ConnectionIdle` to **30s**:

```go
ConnectionIdle: proto.Uint32(30),
```

xray closes a proxied connection once there is no **application-layer** data for `ConnectionIdle` seconds, and it enforces this with a *polling* activity timer (`common/signal/timer.go`): the check runs every `ConnectionIdle` seconds and only fires after a full interval with no activity following the one that consumed the previous activity token — so the **effective** timeout is ~2× the value, i.e. **~60s** for 30.

The result: idle-but-healthy long-lived connections — interactive **SSH**, database/Redis, MQTT, WebSocket — are dropped after ~60s of silence even though the socket is perfectly fine. TCP keepalive does not help (it refreshes the socket, not this application-level timer).

On an affected node, a packet capture of an idle proxied SSH session showed the node itself sending `FIN` at exactly the 60s mark, with TCP keepalives still flowing on both legs — confirming an application-level idle timeout rather than a NAT/socket issue.

### Context

- This project is *modified from* **[wyx2685/v2node](https://github.com/wyx2685/v2node)**, which uses **`ConnectionIdle: 120`**. ppnode lowered it to 30 (4× more aggressive) at some point.
- **xray-core's own default** is **300s** (`SessionDefault`) / **600s** (default manager) — so 30s is ~10–20× more aggressive than xray itself.

### Fix

Restore `ConnectionIdle` to **120**, matching upstream v2node. Verified end-to-end: with 30 an idle SSH tunnel dropped at ~60s every time; with the larger value the same tunnel stays up (no drop observed to 200s+).

> A cleaner long-term fix would be to expose this as a config field (as v2node/V2bX do) instead of a hardcoded constant, so operators can tune it without patching source.
